### PR TITLE
Minor CSS adjusments

### DIFF
--- a/src/jquery.dragon.js
+++ b/src/jquery.dragon.js
@@ -218,7 +218,7 @@
     // Remove the "draggable" attribute so that text within the element can be
     // selected when the element is not being dragged.
     $el.attr('draggable', 'false');
-    $el.removeClass('isDragging');
+    $el.removeClass('is-dragging');
 
     if (isTouch) {
       $doc.off('touchend', data.onTouchEnd)
@@ -318,7 +318,7 @@
     }
 
     $el
-      .addClass('isDragging')
+      .addClass('is-dragging')
       .css(ZERO_OUT_RIGHT_AND_BOTTOM)
       .offset(newCoords);
     fire('drag', $el, evt);

--- a/src/jquery.dragon.js
+++ b/src/jquery.dragon.js
@@ -89,18 +89,10 @@
 
     $els.each(function (i, el) {
       var $el = $(el);
-      var position = $el.position();
-      var top = position.top;
-      var left = position.left;
 
       $el.data('isDragonEnabled', true);
 
       $el
-        .css({
-          'top': top
-          ,'left': left
-          ,'position': 'absolute'
-        })
         .data('dragon', {})
         .data('dragon-opts', opts);
 

--- a/src/jquery.dragon.js
+++ b/src/jquery.dragon.js
@@ -27,6 +27,9 @@
    * Options:
    *
    *   @param {boolean} noCursor Prevents the drag cursor from being "move"
+   *   @param {boolean} noInitialPosition Prevent setting the initial inline
+   *   styles for top, left, and position (they are set once the user begins
+   *   dragging regardless).  False by default.
    *   @param {string} axis The axis to constrain dragging to.  Either 'x' or
    *     'y'.  Disabled by default.
    *   @param {jQuery} within The jQuery'ed element's bounds to constrain the
@@ -91,6 +94,18 @@
       var $el = $(el);
 
       $el.data('isDragonEnabled', true);
+
+      if (!opts.noInitialPosition) {
+        var position = $el.position();
+        var top = position.top;
+        var left = position.left;
+
+        $el.css({
+          top: top
+          ,left: left
+          ,position: 'absolute'
+        });
+      }
 
       $el
         .data('dragon', {})

--- a/src/jquery.dragon.js
+++ b/src/jquery.dragon.js
@@ -226,6 +226,7 @@
     // Remove the "draggable" attribute so that text within the element can be
     // selected when the element is not being dragged.
     $el.attr('draggable', 'false');
+    $el.removeClass('isDragging');
 
     if (isTouch) {
       $doc.off('touchend', data.onTouchEnd)
@@ -325,6 +326,7 @@
     }
 
     $el
+      .addClass('isDragging')
       .css(ZERO_OUT_RIGHT_AND_BOTTOM)
       .offset(newCoords);
     fire('drag', $el, evt);


### PR DESCRIPTION
Thanks for this plugin, it's simple and was just perfect for my needs. I had to tweak couple of things to help with me styling:

1. Add ```isDragging``` CSS class while the element is being dragged. I use it to reduce opacity.
2. Remove the initial positioning, so I could define my own in CSS, which is set to the right of the screen.

